### PR TITLE
[Docs] Bump patch level to pick up doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.4
+  - Docs: Bump patch level to pick up new plugin description
+  
+## 3.0.3
+  - Docs: Bump patch level for doc build
+  
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/logstash-codec-dots.gemspec
+++ b/logstash-codec-dots.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-dots'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Codec that outputs dots"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The changes to the description were made after the patch level was bumped, so I bumped it again to make sure the description gets picked up and the doc build doesn't break.